### PR TITLE
Concurrent access lightController fix

### DIFF
--- a/core/src/com/fallenflame/game/CharacterModel.java
+++ b/core/src/com/fallenflame/game/CharacterModel.java
@@ -168,11 +168,6 @@ public abstract class CharacterModel extends WheelObstacle {
         walkLimit = value;
     }
 
-    /** Return character default max speed */
-    protected float getDefaultMaxSpeed() {
-        return 4;
-    }
-
     /**
      * Gets light radius for character
      * @return light radius
@@ -206,15 +201,15 @@ public abstract class CharacterModel extends WheelObstacle {
 
         // Technically, we should do error checking here.
         // A JSON field might accidentally be missing
-        setBodyType(BodyDef.BodyType.DynamicBody);
-        setDensity(1);
-        setFriction(0);
-        setRestitution(0);
-        setForce(80);
-        setDamping(10);
-        setMaxSpeed(getDefaultMaxSpeed());
-        setStartFrame(0);
-        setWalkLimit(4);
+        setBodyType(json.get("bodytype").asString().equals("static") ? BodyDef.BodyType.StaticBody : BodyDef.BodyType.DynamicBody);
+        setDensity(json.get("density").asFloat());
+        setFriction(json.get("friction").asFloat());
+        setRestitution(json.get("restitution").asFloat());
+        setForce(json.get("force").asFloat());
+        setDamping(json.get("damping").asFloat());
+        setMaxSpeed(json.get("maxspeed").asFloat());
+        setStartFrame(json.get("startframe").asInt());
+        setWalkLimit(json.get("walklimit").asInt());
 
         // Reflection is best way to convert name to color
 //        Color debugColor;
@@ -228,6 +223,16 @@ public abstract class CharacterModel extends WheelObstacle {
 //        int opacity = json.get("debugopacity").asInt();
 //        debugColor.mul(opacity/255.0f);
 //        setDebugColor(debugColor);
+
+        // Now get the texture from the AssetManager singleton
+        String key = json.get("texture").asString();
+        TextureRegion texture = JsonAssetManager.getInstance().getEntry(key, TextureRegion.class);
+        try {
+            filmstrip = (FilmStrip)texture;
+        } catch (Exception e) {
+            filmstrip = null;
+        }
+        setTexture(texture);
     }
 
     /**

--- a/core/src/com/fallenflame/game/EnemyModel.java
+++ b/core/src/com/fallenflame/game/EnemyModel.java
@@ -1,46 +1,11 @@
 package com.fallenflame.game;
 
-import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.physics.box2d.BodyDef;
-import com.badlogic.gdx.utils.JsonValue;
-import com.fallenflame.game.util.FilmStrip;
-import com.fallenflame.game.util.JsonAssetManager;
 
 public class EnemyModel extends CharacterModel {
     protected boolean activated = false;
 
     protected Vector2 goal;
-    /**
-     * Initializes the player via the given JSON value
-     *
-     * The JSON value has been parsed and is part of a bigger level file.  However,
-     * this JSON value is limited to the player subtree
-     *
-     * @param json	the JSON subtree defining the player
-     */
-    public void initialize(JsonValue json) {
-        super.initialize(json);
-        // Enemy specific initialization
-        setForce(getForce() * 1.4f); // temporary way to make enemy faster than player
-        // Now get the texture from the AssetManager singleton
-        String key = getDefaultTexture(); // TODO: should get from JSON?
-        TextureRegion texture = JsonAssetManager.getInstance().getEntry(key, TextureRegion.class);
-        try {
-            filmstrip = (FilmStrip)texture;
-        } catch (Exception e) {
-            filmstrip = null;
-        }
-        setTexture(texture);
-    }
-
-    protected float getDefaultMaxSpeed() {
-        return super.getDefaultMaxSpeed() * 1.25f;
-    }
-
-    protected String getDefaultTexture() {
-        return "enemy-walking";
-    }
 
     /**
      * Gets enemy's active status

--- a/core/src/com/fallenflame/game/LightController.java
+++ b/core/src/com/fallenflame/game/LightController.java
@@ -11,10 +11,7 @@ import com.badlogic.gdx.utils.JsonValue;
 import com.fallenflame.game.physics.lights.PointSource;
 import com.fallenflame.game.physics.obstacle.Obstacle;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Logger;
 
 /**
@@ -175,12 +172,17 @@ public class LightController {
             attachLightTo(f, i);
             flareLights.put(i, f);
         });
-        enemyLights.keySet().stream().filter(i -> !enemies.contains(i) || !i.getActivated()).forEach(i -> {
-            PointSource f = enemyLights.get(i);
-            f.setActive(false);
-            f.dispose();
-            enemyLights.remove(i);
-        });
+        // Iterate through all enemy lights and if the enemy is no longer activated or the enemy is gone, remove the light
+        Iterator<EnemyModel> iter = enemyLights.keySet().iterator();
+        while(iter.hasNext()){
+            EnemyModel e = iter.next();
+            if(!enemies.contains(e) || !e.getActivated()){
+                PointSource f = enemyLights.get(e);
+                f.setActive(false);
+                f.dispose();
+                iter.remove();
+            }
+        }
         enemies.stream().filter(i -> !enemyLights.containsKey(i)).forEach(i -> {
             PointSource f = createPointLight(i.getLightRadius());
             attachLightTo(f, i);

--- a/core/src/com/fallenflame/game/PlayerModel.java
+++ b/core/src/com/fallenflame/game/PlayerModel.java
@@ -1,9 +1,5 @@
 package com.fallenflame.game;
 
-import com.badlogic.gdx.utils.*;
-import com.badlogic.gdx.graphics.g2d.*;
-import com.fallenflame.game.util.*;
-
 /**
  * Player avatar for the plaform game.
  *
@@ -13,33 +9,6 @@ import com.fallenflame.game.util.*;
 public class PlayerModel extends CharacterModel {
     /** Radius of player's light */
     protected float lightRadius = 0;
-
-    /**
-     * Initializes the player via the given JSON value
-     *
-     * The JSON value has been parsed and is part of a bigger level file.  However,
-     * this JSON value is limited to the player subtree
-     *
-     * @param json	the JSON subtree defining the player
-     */
-    public void initialize(JsonValue json) {
-        super.initialize(json);
-        // Enemy specific initialization
-        // Now get the texture from the AssetManager singleton
-        String key = getDefaultTexture(); // TODO: should get from JSON? --> json.get("texture").asString();
-        TextureRegion texture = JsonAssetManager.getInstance().getEntry(key, TextureRegion.class);
-        try {
-            filmstrip = (FilmStrip)texture;
-        } catch (Exception e) {
-            filmstrip = null;
-        }
-        setTexture(texture);
-    }
-
-    /** Return player default texture */
-    protected String getDefaultTexture() {
-        return "player";
-    }
 
     /**
      * Gets player light radius


### PR DESCRIPTION
Issue is for this code:
```
enemyLights.keySet().stream().filter(i -> !enemies.contains(i) || !i.getActivated()).forEach(i -> {
            PointSource f = enemyLights.get(i);
            f.setActive(false);
            f.dispose();
            enemyLights.remove(i);
        });
```
You can't stream/filter over enemyLights.keySet() while simultaneously changing the size of enemyLights.keySet() (via `enemyLights.remove(i);`).

I can rewrote this to use an iterator with appropriate removal to not cause a concurrent access issue