### PR TITLE
Pathing enemy

### DIFF
--- a/core/assets/jsons/levels/easy.json
+++ b/core/assets/jsons/levels/easy.json
@@ -30,7 +30,14 @@
         5,
         5
       ],
-      "enemytype": "typeA"
+      "enemytype": "typeA",
+      "subtype": "pathing",
+      "pathCoors": [
+        [7.7, 5.1],
+        [14.45, 1.34],
+        [14.45, 7.61],
+        [5, 5]
+      ]
     },
     {
       "enemypos": [

--- a/core/src/com/fallenflame/game/LevelController.java
+++ b/core/src/com/fallenflame/game/LevelController.java
@@ -392,7 +392,11 @@ public class LevelController implements ContactListener {
             enemies.add(enemy);
             // Initialize AIController
             if(enemyType.equals("typeA")) {
-                AIControllers.add(new AITypeAController(enemyID, levelModel, enemies, player, flares));
+                // If subtype pathing, give pathCoors as input as well
+                if(enemyJSON.has("subtype") && enemyJSON.get("subtype").asString().equals("pathing"))
+                    AIControllers.add(new AITypeAController(enemyID, levelModel, enemies, player, flares, enemyJSON.get("pathCoors")));
+                else
+                    AIControllers.add(new AITypeAController(enemyID, levelModel, enemies, player, flares));
             }
             else if(enemyType.equals("typeB")) {
                 AIControllers.add(new AITypeBController(enemyID, levelModel, enemies, player));

--- a/core/src/com/fallenflame/game/enemies/AITypeAController.java
+++ b/core/src/com/fallenflame/game/enemies/AITypeAController.java
@@ -2,6 +2,7 @@ package com.fallenflame.game.enemies;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.JsonValue;
 import com.fallenflame.game.FlareModel;
 import com.fallenflame.game.LevelModel;
 import com.fallenflame.game.PlayerModel;
@@ -9,6 +10,11 @@ import com.fallenflame.game.enemies.EnemyModel;
 
 import java.util.*;
 
+/**
+ * This class is the AI Controller for all moving enemies.
+ * Subtype Default: enemy stands still when idle
+ * Subtype Pathing: enemy follows a path when idle
+ */
 public class AITypeAController extends AIController {
     /**
      * Enumeration to encode the finite state machine.
@@ -36,6 +42,10 @@ public class AITypeAController extends AIController {
     private EnemyTypeAModel enemy;
     /** The flares in the world */
     private List<FlareModel> flares;
+    /** Pathing step coordinates - Null for enemies not of subtype Pathing */
+    private Vector2[] pathCoors;
+    /** Current point in path */
+    private int pathPoint;
 
     /**
      * Creates an AIController for the enemy with the given id.
@@ -53,7 +63,37 @@ public class AITypeAController extends AIController {
         assert(enemy.getClass() == EnemyTypeAModel.class);
         this.enemy = (EnemyTypeAModel)super.enemy;
         this.flares = flares;
+        pathCoors = null;
         state = FSMState.IDLE;
+    }
+
+    /**
+     * Creates an AIController for an enemy of subtype pathing.
+     *
+     * @param id The unique enemy identifier
+     * @param level The game level (for pathfinding)
+     * @param enemies The list of enemies
+     * @param player The player to target
+     * @param flares The flares that may attract the enemy
+     */
+    public AITypeAController(int id, LevelModel level, List<EnemyModel> enemies, PlayerModel player,
+                             List<FlareModel> flares, JsonValue pathCoorsJSON) {
+        super(id, level, enemies);
+        this.player = player;
+        assert(enemy.getClass() == EnemyTypeAModel.class);
+        this.enemy = (EnemyTypeAModel)super.enemy;
+        this.flares = flares;
+        state = FSMState.IDLE;
+        // unpack pathing coordinates
+        Vector2[] pathCoors = new Vector2[pathCoorsJSON.size];
+        for(int i=0; i<pathCoorsJSON.size; i++) {
+            int[] coor = pathCoorsJSON.get(i).asIntArray();
+            pathCoors[i] = new Vector2(coor[0], coor[1]);
+        }
+        this.pathCoors = pathCoors;
+        // initialize pathing
+        pathPoint = 0;
+        enemy.setInvestigatePosition(pathCoors[pathPoint]);
     }
 
     /**
@@ -76,6 +116,14 @@ public class AITypeAController extends AIController {
                         enemy.setInvestigatePosition(new Vector2(f.getX(), f.getY()));
                         enemy.setInvestigateFlare(f);
                         break;
+                    }
+                }
+                // If enemy is of subtype pathing
+                if(pathCoors != null) {
+                    // update investigation position
+                    if(investigateReached()) {
+                        pathPoint = (pathPoint + 1) % pathCoors.length;
+                        enemy.setInvestigatePosition(pathCoors[pathPoint]);
                     }
                 }
                 break;
@@ -110,6 +158,10 @@ public class AITypeAController extends AIController {
                     enemy.setInvestigatePosition(null);
                     enemy.clearInvestigateFlare();
                     state = FSMState.IDLE;
+                    // If enemy is of subtype pathing
+                    if(pathCoors != null){
+                        enemy.setInvestigatePosition(pathCoors[pathPoint]);
+                    }
                 }
                 break;
 
@@ -126,6 +178,11 @@ public class AITypeAController extends AIController {
     protected void markGoalTiles() {
         switch(state) {
             case IDLE:
+                // If enemy is of subtype pathing
+                if(pathCoors != null){
+                    level.setGoal(level.screenToTile(enemy.getInvestigatePositionX()),
+                            level.screenToTile(enemy.getInvestigatePositionY()));
+                }
                 break; // no goal tile
 
             case CHASE:


### PR DESCRIPTION
Pathing enemy! When in an idle state, the enemy will follow a set of predefined points. When distracted by a flare or player, the enemy will give chase, and when finished investigating, will return to their pathing.

To make a pathing enemy, **in the level JSON** for the desired enemy set field `"enemytype"` as `"typeA"` and then set the field `"subtype"` to `"pathing"`. This will require you to then create and populate a `"pathCoors"` field with coordinates for the enemy, defined like this example: 
`"pathCoors": [
        [7.7, 5.1],
        [14.45, 1.34],
        [14.45, 7.61],
        [5, 5]
      ]`

**Note: this will require addition of new level editor support**, however this is backwards compatible beacuse if no `"subtype"` is defined, it will be interpreted as default `"typeA"` (aka our current typeA enemy.