### PR TITLE
Make runner prioritize flares and change flare burnout behavior

### DIFF
--- a/core/assets/jsons/global.json
+++ b/core/assets/jsons/global.json
@@ -145,7 +145,7 @@
   "flare" : {
     "radius":      	  0.1,
     "lighradius":     3.5,
-    "flareduration":  6000,
+    "flareduration":  1500,
     "bodytype":    	  "dynamic",
     "density":        1.0,
     "friction":       0.0,
@@ -153,7 +153,7 @@
     "texture":        "fire",
     "shotsound":      "flareshot",
     "burnoutsound":   "flareout",
-    "initialforce":   3.0,
+    "initialforce":   3.5,
     "damping": 		 0.0,
     "tint": [1.0, 1.0, 1.0, 1.0],
     "startframe":       0

--- a/core/src/com/fallenflame/game/FlareModel.java
+++ b/core/src/com/fallenflame/game/FlareModel.java
@@ -30,8 +30,8 @@ public class FlareModel extends WheelObstacle implements ILight {
     /** How long a flare can last, in milliseconds. */
     private int flareDuration;
 
-    /** Time when it was fired **/
-    private long startTime;
+    /** Time when flare stuck to wall **/
+    private long stuckTime;
 
     /** Light Radius */
     private float lightRadius;
@@ -183,7 +183,6 @@ public class FlareModel extends WheelObstacle implements ILight {
         super(pos.x,pos.y,1.0f);
         setFixedRotation(false);
         this.setSensor(true);
-        startTime = System.currentTimeMillis();
     }
 
     /**
@@ -269,6 +268,7 @@ public class FlareModel extends WheelObstacle implements ILight {
     public void stopMovement() {
         body.setLinearVelocity(new Vector2(0,0));
         isStuck = true;
+        stuckTime = System.currentTimeMillis();
     }
 
     /**
@@ -289,11 +289,12 @@ public class FlareModel extends WheelObstacle implements ILight {
 
     /**
      * How long until flare is deactived
-     * @return time left
+     * @return 1 if flare is not yet stuck to wall, otherwise returns stuck time left until burnout
      */
     public int timeToBurnout() {
-        int timeLeft = flareDuration - (int) (System.currentTimeMillis() - startTime);
-        return Math.max(timeLeft, 0);
+        if(isStuck)
+            return Math.max(flareDuration - (int) (System.currentTimeMillis() - stuckTime), 0);
+        return 1;
     }
 
     /**


### PR DESCRIPTION
Running enemy now:
- Prioritizes flares over the player 
- Whenever it can see a flare, it will ignore the player in favor of it

Changed flare burnout behavior as well for balancing. Burnout countdown now does not start until flare has hit a wall. I also adjusted the timeout time and speed for balancing.