### PR TITLE
Temp Solution to go back to menu after completing level

### DIFF
--- a/core/src/com/fallenflame/game/GDXRoot.java
+++ b/core/src/com/fallenflame/game/GDXRoot.java
@@ -23,6 +23,8 @@ import com.fallenflame.game.util.*;
 public class GDXRoot extends Game implements ScreenListener {
 	/** Drawing context to display graphics */
 	private GameCanvas canvas;
+	/** Drawing context to display level select */
+	private GameCanvas levelCanvas;
 	/** Asset Loading Screen. What will show  */
 	private LoadingMode loading;
 	/** Player mode for the the game */
@@ -43,8 +45,9 @@ public class GDXRoot extends Game implements ScreenListener {
 	 */
 	public void create() {
 		canvas  = new GameCanvas();
+		levelCanvas = new GameCanvas();
 		loading = new LoadingMode(canvas,1);
-		levelSelect = new LevelSelectMode(canvas);
+		levelSelect = new LevelSelectMode(levelCanvas);
 		engine = new GameEngine();
 		InputMultiplexer multiplexer = new InputMultiplexer(); //Allows for multiple InputProcessors
 		//Multiplexer is an ordered list, so when an event occurs, it'll check loadingMode first, and then GameEngine
@@ -70,6 +73,7 @@ public class GDXRoot extends Game implements ScreenListener {
 		engine.unloadContent();
 		engine.dispose();
 		canvas.dispose();
+		levelCanvas.dispose();
 		canvas = null;
 
 		// Unload all of the resources
@@ -116,14 +120,18 @@ public class GDXRoot extends Game implements ScreenListener {
 			loading.dispose();
 			loading = null;
 		} else if (screen == levelSelect) {
+			engine.resume();
 			Gdx.input.setInputProcessor(engine);
 			engine.setScreenListener(this);
 			engine.setCanvas(canvas);
 			engine.reset(levelSelect.getLevelSelected());
 			setScreen(engine);
-
-			levelSelect.dispose();
-			levelSelect = null;
+		} else if (screen == engine) {
+			Gdx.input.setInputProcessor(levelSelect);
+			levelSelect.setScreenListener(this);
+			setScreen(levelSelect);
+			engine.pause();
+			levelSelect.reset();
 		} else if (exitCode == engine.EXIT_QUIT) {
 			// We quit the main application
 			Gdx.app.exit();

--- a/core/src/com/fallenflame/game/GameEngine.java
+++ b/core/src/com/fallenflame/game/GameEngine.java
@@ -321,7 +321,7 @@ public class GameEngine implements Screen, InputProcessor {
             }
         }
         if (exitPressed && !exitPrevious) {
-            listener.exitScreen(this, EXIT_QUIT);
+            listener.exitScreen(this, 0);
             return false;
         }
         //If countdown is > -1, then the player must have won or lost. Either continue to show the win condition message
@@ -460,6 +460,7 @@ public class GameEngine implements Screen, InputProcessor {
      * also paused before it is destroyed.
      */
     public void pause() {
+        level.stopAllSounds();
        isPaused = true;
     }
 

--- a/core/src/com/fallenflame/game/LevelController.java
+++ b/core/src/com/fallenflame/game/LevelController.java
@@ -573,6 +573,12 @@ public class LevelController implements ContactListener {
         }
     }
 
+    public void stopAllSounds(){
+        for(EnemyModel e : enemies){
+            e.getActiveSound().stop();
+        }
+    }
+
     /**
      * Fixes the physics frame rate to be in sync with the animation framerate
      *

--- a/core/src/com/fallenflame/game/LevelSelectMode.java
+++ b/core/src/com/fallenflame/game/LevelSelectMode.java
@@ -114,6 +114,8 @@ public class LevelSelectMode implements Screen, InputProcessor {
         heightY = height;
     }
 
+    public void reset() { pressState = 0; }
+
     @Override
     public void pause() {
 


### PR DESCRIPTION
This is a temporary solution for the presentation tomorrow. You can now press `esc` to exit the level and go back to level select.
Current issues:
- **Sounds keep playing.** For some reason, unable to stop enemy sounds, other models don't have a way to get active sounds. This needs to be fixed, but may not be an issue for the presentation.
- I had to create 2 GameCanvas's in gdxRoot: one for GameEngine and one for LevelSelectMode. This is because Engine does things to the GameCanvas that I am having trouble reverting (such as moving the camera and changing font colors etc). 

This solution is not the most ideal, but works for now.