### PR TITLE
Make flares a limited resource

### DIFF
--- a/core/assets/jsons/global.json
+++ b/core/assets/jsons/global.json
@@ -10,7 +10,7 @@
     "maxspeed": 	  5.0,
     "startframe":       0,
     "walklimit":		4,
-    "flarecount":       5,
+    "standardflarecount": 5,
     "sprintlightrad":  10,
     "sneaklightrad":    1,
     "minlightradius":   2,

--- a/core/assets/jsons/levels/easy.json
+++ b/core/assets/jsons/levels/easy.json
@@ -14,6 +14,8 @@
     1.5
   ],
   "startSneakVal" : 200,
+  "startFlareCount": 4,
+  "maxFlareCount": 4,
   "exitpos": [
     1.5,
     5.35

--- a/core/src/com/fallenflame/game/LevelController.java
+++ b/core/src/com/fallenflame/game/LevelController.java
@@ -401,10 +401,7 @@ public class LevelController implements ContactListener {
         // Create player
         player = new PlayerModel();
         player.setDrawScale(scale);
-        if(levelJson.has("startSneakVal"))
-            player.initialize(globalJson.get("player"), levelJson.get("playerpos").asFloatArray(), levelJson.get("startSneakVal").asInt());
-        else
-            player.initialize(globalJson.get("player"), levelJson.get("playerpos").asFloatArray());
+        player.initialize(globalJson.get("player"), levelJson);
         player.initializeTextures(globalJson.get("player"));
         player.activatePhysics(world);
         assert inBounds(player);
@@ -711,7 +708,7 @@ public class LevelController implements ContactListener {
      * @param mousePosition Position of mouse when flare launched
      */
     public void createFlare(Vector2 mousePosition, Vector2 screenDimensions){
-        if (flares.size() < player.getFlareCount()) {
+        if (player.getFlareCount() > 0) {
             FlareModel flare = new FlareModel(player.getPosition());
             flare.setDrawScale(scale);
             flare.initialize(flareJSON);
@@ -724,6 +721,7 @@ public class LevelController implements ContactListener {
             flare.getShotSound().play();
             flares.add(flare);
             assert inBounds(flare);
+            player.decFlareCount();
         }
     }
 
@@ -892,11 +890,11 @@ public class LevelController implements ContactListener {
         float flareWidth = activeFlareCountTexture.getRegionWidth() + flareCountSplit * scale.x;
 
         if (activeFlareCountTexture != null && inactiveFlareCountTexture != null) {
-            for (int i = 0; i <= player.getFlareCount() - flares.size() - 1; i++) {
+            for (int i = 0; i <= player.getFlareCount()  - 1; i++) {
                 float activeFlareX = ox + i * flareWidth;
                 canvas.draw(activeFlareCountTexture, activeFlareX, oy);
             }
-            for (int j = player.getFlareCount() - flares.size(); j < player.getFlareCount(); j++){
+            for (int j = player.getFlareCount() ; j < player.getMaxFlareCount(); j++){
                 float inactiveFlareX = ox + j * flareWidth;
                 canvas.draw(inactiveFlareCountTexture, inactiveFlareX, oy);
             }

--- a/core/src/com/fallenflame/game/PlayerModel.java
+++ b/core/src/com/fallenflame/game/PlayerModel.java
@@ -24,7 +24,9 @@ public class PlayerModel extends CharacterModel {
     /** How the player is currently moving */
     private MovementState move;
 
-    /** Number of flares the player can have on the screen at once */
+    /** Max flares player can hold. Also determines UI flare indicators */
+    private int maxFlareCount;
+    /** Number of flares the player has left */
     private int flareCount;
     /** Player's force when moving at standard walk speed */
     protected float forceWalk;
@@ -62,28 +64,29 @@ public class PlayerModel extends CharacterModel {
     /**
      * Initializes the character via the given JSON value
      *
-     * @param json	the JSON subtree defining the player
+     * @param globalJson	the JSON subtree defining global player data
+     * @param levelJson     the JSON subtree defining level data
      */
-    public void initialize(JsonValue json, float[] pos, int startSneakVal) {
-        super.initialize(json, pos);
-        flareCount = json.get("flarecount").asInt();
+    public void initialize(JsonValue globalJson, JsonValue levelJson) {
+        super.initialize(globalJson, levelJson.get("playerpos").asFloatArray());
+        flareCount = levelJson.has("startFlareCount") ?
+                levelJson.get("startFlareCount").asInt() : globalJson.get("standardflarecount").asInt();
+        maxFlareCount = levelJson.has("startFlareCount") ?
+                levelJson.get("startFlareCount").asInt() : globalJson.get("standardflarecount").asInt();
         forceWalk = getForce();
-        lightRadiusSprint = json.get("sprintlightrad").asInt();
-        lightRadiusSneak = json.get("sneaklightrad").asInt();
-        minLightRadius = json.get("minlightradius").asInt();
-        sneakVal = startSneakVal;
+        lightRadiusSprint = globalJson.get("sprintlightrad").asInt();
+        lightRadiusSneak = globalJson.get("sneaklightrad").asInt();
+        minLightRadius = globalJson.get("minlightradius").asInt();
+        sneakVal = levelJson.has("startSneakVal") ?
+                levelJson.get("startSneakVal").asInt() : globalJson.get("defaultStartSneakVal").asInt();
         lightRadius = minLightRadius;
         move = MovementState.WALK;
 
-        float[] tintValues = json.get("tint").asFloatArray();//RGBA
+        float[] tintValues = globalJson.get("tint").asFloatArray();//RGBA
         tint = new Color(tintValues[0], tintValues[1], tintValues[2], tintValues[3]);
 
-        String walkSoundKey = json.get("walksound").asString();
+        String walkSoundKey = globalJson.get("walksound").asString();
         walkSound = JsonAssetManager.getInstance().getEntry(walkSoundKey, Sound.class);
-    }
-
-    public void initialize(JsonValue json, float[] pos) {
-        initialize(json, pos, json.get("defaultStartSneakVal").asInt());
     }
 
     @Override
@@ -209,13 +212,21 @@ public class PlayerModel extends CharacterModel {
     public float getMinLightRadius() { return minLightRadius; }
 
     /**
-     * Returns the number of flares the player can have on the screen at once
-     *
-     * @return the number of flares the player can have on the screen at once
+     * Returns max flare count
      */
-    public int getFlareCount() {
-        return flareCount;
-    }
+    public int getMaxFlareCount() { return maxFlareCount; }
+
+    /**
+     * Returns the number of flares the player has left
+     *
+     * @return the number of flares the player has left
+     */
+    public int getFlareCount() { return flareCount; }
+
+    /**
+     * Decrement flare count (for firing a flare)
+     */
+    public void decFlareCount() { flareCount--; }
 
     /**
      * Gets player light radius


### PR DESCRIPTION
Made player have set number of flares at start of level that is decremented every time they fire. Currently no way to regain flares (working on pick-up).

Also please note for **level editor**:
- `"startFlareCount"` defines how many flares the player starts with
- `"maxFlareCount"` defines the max flares a player can hold and what the UI shows (will come in to play with pick-ups)
I differentiated these in case we want a level where you start out with few, but pick up more later. Also note, both of these have **global default values of 5 to allow for backwards compatibility.**