### PR TITLE
Floor & reset fix

### DIFF
--- a/core/src/com/fallenflame/game/GameEngine.java
+++ b/core/src/com/fallenflame/game/GameEngine.java
@@ -286,7 +286,7 @@ public class GameEngine implements Screen, InputProcessor {
      * reread from the JSON file, allowing us to make changes on the fly.
      */
     public void reset() {
-        reset(0);
+        reset(lastLevelPlayed);
     }
 
     /**

--- a/core/src/com/fallenflame/game/LevelController.java
+++ b/core/src/com/fallenflame/game/LevelController.java
@@ -813,7 +813,8 @@ public class LevelController implements ContactListener {
         canvas.begin();
         //draw background
         if (background != null) {
-            canvas.draw(background, Color.WHITE, 0,0, (float) canvas.getWidth(), (float) canvas.getHeight());
+            canvas.draw(background, Color.WHITE, 0,0,
+                    bounds.width * scale.x, bounds.width * scale.y);
         }
 
         // Draw all objects


### PR DESCRIPTION
This PR fixes two issues:

- Wall texture cuts off when level bounds get bigger than screen
- Press "R" resets to the first level rather than the current playing level