### PR TITLE
Add gradual light effect

### DIFF
--- a/core/src/com/fallenflame/game/LightController.java
+++ b/core/src/com/fallenflame/game/LightController.java
@@ -95,6 +95,8 @@ public class LightController {
     protected Map<PointSource, Float> animateOut;
     protected int animateTicks;
 
+    private float targetPlayerRadius;
+
     protected boolean debug;
 
     protected float scale;
@@ -135,6 +137,7 @@ public class LightController {
 
         // Create player light.
         playerLight = createPointLight(player.getLightRadius(), player.getTextureX(), player.getTextureY());
+        targetPlayerRadius = player.getLightRadius();
 
         // Create exit light.
         exitLight = createPointLight(exit.getLightRadius(), exit.getX(), exit.getY());
@@ -249,6 +252,16 @@ public class LightController {
             }
             return false;
         });
+       float pLightCurrDist = playerLight.getDistance();
+       if (pLightCurrDist != targetPlayerRadius) {
+           if (Math.abs(pLightCurrDist - targetPlayerRadius) < 0.05) {
+               playerLight.setDistance(targetPlayerRadius);
+           } else if (pLightCurrDist < targetPlayerRadius) {
+               playerLight.setDistance(pLightCurrDist + (targetPlayerRadius - pLightCurrDist) * 0.5f);
+           } else {
+               playerLight.setDistance(pLightCurrDist - (pLightCurrDist - targetPlayerRadius) * 0.5f);
+           }
+       }
     }
 
     private void updateCamera() {
@@ -275,7 +288,7 @@ public class LightController {
         updateCamera();
 
         // Update player light.
-        playerLight.setDistance(player.getLightRadius());
+        targetPlayerRadius = player.getLightRadius();
         playerLight.setPosition(player.getTextureX(), player.getTextureY());
 
         // Update flare lights.


### PR DESCRIPTION
This PR adds a transition for player light. A change in light radius will be rendered automatically with a rapid animation.

This does _not_ change the light radius in player model, so anything that relies on it (AI and whatnot) will use the real raw value. The transition is applied only in light controller when rendering the player light. However, the animation should be fast enough that it wouldn't cause an issue where the "light" AI sees and the light player sees feels out of sync.