### PR TITLE
add delay to end of player death animation

### DIFF
--- a/core/assets/jsons/global.json
+++ b/core/assets/jsons/global.json
@@ -23,6 +23,7 @@
       "death-left": "player-death-left",
       "death-right": "player-death-right"
     },
+    "deathdelay": 45,
     "walksound":    "new-walk",
     "firebuddy": {
       "texture": {

--- a/core/src/com/fallenflame/game/PlayerModel.java
+++ b/core/src/com/fallenflame/game/PlayerModel.java
@@ -73,6 +73,9 @@ public class PlayerModel extends CharacterModel {
     private FilmStrip deathFilmstripRight;
     private FilmStrip deathFilmstripLeft;
 
+    /** Frames until player finishes dying and is considered dead */
+    private int deathDelay;
+
     /**
      * Initializes the character via the given JSON value
      *
@@ -106,6 +109,8 @@ public class PlayerModel extends CharacterModel {
         life = LifeState.ALIVE;
 
         throwing = false;
+
+        deathDelay = globalJson.get("deathdelay").asInt();
     }
 
     @Override
@@ -231,9 +236,10 @@ public class PlayerModel extends CharacterModel {
     /**
      * Get the position of the firebuddy on the screen in meters
      */
-    public Vector2 getFireBuddyPosition() { return new
-            Vector2(getPosition().x + (getFireBuddyOriginX() + fireBuddyFilmstrip.getRegionWidth()) / drawScale.x / 2.0f,
-            getPosition().y - (getFireBuddyOriginY() / drawScale.y) + fireBuddyFilmstrip.getRegionHeight() / drawScale.y / 2.0f);}
+    public Vector2 getFireBuddyPosition() { return new Vector2(
+            getPosition().x + (getFireBuddyOriginX() + fireBuddyFilmstrip.getRegionWidth()) / drawScale.x / 2.0f,
+            getPosition().y - (getFireBuddyOriginY() / drawScale.y) + fireBuddyFilmstrip.getRegionHeight() / drawScale.y / 2.0f);
+    }
 
     /**
      * @return the origin of the firebuddy texture when sneaking
@@ -418,8 +424,6 @@ public class PlayerModel extends CharacterModel {
         if(angle < 0) angle = angle + 2 * Math.PI;
         int angle100 = (int) (angle * 100);
 
-        animateFireBuddy(angle100);
-
         if(isDying()) {
             if (angle100 > 0 && angle100 < 314 && deathFilmstripLeft != null) {
                 filmstrip = deathFilmstripLeft;
@@ -435,10 +439,14 @@ public class PlayerModel extends CharacterModel {
                 filmstrip.setFrame(frame + 1);
             } else if (walkCool > 0) {
                 walkCool--;
-            } else if (frame == filmstrip.getSize() - 1){
+            } else if (deathDelay <= 0){
                 life = LifeState.DEAD;
+            } else if (frame == filmstrip.getSize() - 1) {
+                deathDelay--;
             }
+
         } else if (isAlive()) {
+            animateFireBuddy(angle100);
             super.update(dt);
         }
     }


### PR DESCRIPTION
Adds a number of frames to the end of the player death animation before the player is considered "dead" by the game and the "game over" screen pops up 