### PR TITLE
Remove light scrolling from player; make debug option

### DIFF
--- a/core/src/com/fallenflame/game/ControlMode.java
+++ b/core/src/com/fallenflame/game/ControlMode.java
@@ -70,7 +70,7 @@ public class ControlMode implements Screen, InputProcessor {
         InputBindings.Control[] cvalues = InputBindings.Control.values();
         int totalControls = cvalues.length;
         boolean bindingInProgress = Arrays.stream(controlStates).anyMatch(i -> i == 2);
-        for (int ind = 0, j = totalControls + 2; ind < j; ind++) {
+        for (int ind = 0, j = totalControls + 1; ind < j; ind++) {
             float ry = screenHeight - (((ind + 1) / (float) totalControls) * (screenHeight - 240) + 55);
             displayFont.setColor(controlStates[ind] == 1 && ind < totalControls ? Color.CYAN :
                     (controlStates[ind] == 2 ? Color.YELLOW :
@@ -81,16 +81,8 @@ public class ControlMode implements Screen, InputProcessor {
                 str2 = InputBindings.controlToString(cvalues[ind]);
                 str = InputBindings.keyToString(InputBindings.getBindingOf(cvalues[ind]));
             } else {
-                switch (ind - totalControls) {
-                    case 1:
-                        str2 = "Change light radius (primary)";
-                        str = "Mouse wheel";
-                        break;
-                    case 0:
-                        str2 = "Flare";
-                        str = "Move mouse to aim, left click to shoot";
-                        break;
-                }
+                str2 = "Flare";
+                str = "Move mouse to aim, left click to shoot";
             }
             GlyphLayout box2 = new GlyphLayout(displayFont, str2);
             canvas.drawText(str2, displayFont,

--- a/core/src/com/fallenflame/game/GameEngine.java
+++ b/core/src/com/fallenflame/game/GameEngine.java
@@ -51,7 +51,7 @@ public class GameEngine implements Screen, InputProcessor {
 
     /**Boolean to determine if debug keys do anything.
      * Note: MUST BE FALSE WHEN MAKING A JAR! */
-    private static final boolean ALLOW_DEBUG = true;
+    private static final boolean ALLOW_DEBUG = false;
 
     private static final String SAVE_PATH = "savedata/save.json";
     private LevelSave[] levelSaves;

--- a/core/src/com/fallenflame/game/GameEngine.java
+++ b/core/src/com/fallenflame/game/GameEngine.java
@@ -51,7 +51,7 @@ public class GameEngine implements Screen, InputProcessor {
 
     /**Boolean to determine if debug keys do anything.
      * Note: MUST BE FALSE WHEN MAKING A JAR! */
-    private static final boolean ALLOW_DEBUG = false;
+    private static final boolean ALLOW_DEBUG = true;
 
     private static final String SAVE_PATH = "savedata/save.json";
     private LevelSave[] levelSaves;
@@ -688,10 +688,10 @@ public class GameEngine implements Screen, InputProcessor {
         }
 
         //#region mouse wheel alternative
-        if(Gdx.input.isKeyPressed(InputBindings.getBindingOf(InputBindings.Control.INCREASE_LIGHT))){
+        if(Gdx.input.isKeyPressed(Input.Keys.PERIOD) && ALLOW_DEBUG){
             level.lightFromPlayer(0.5f);
         }
-        if(Gdx.input.isKeyPressed(InputBindings.getBindingOf(InputBindings.Control.DECREASE_LIGHT))){
+        if(Gdx.input.isKeyPressed(Input.Keys.COMMA) && ALLOW_DEBUG){
             level.lightFromPlayer(-0.5f);
         }
         //#endregion

--- a/core/src/com/fallenflame/game/GameEngine.java
+++ b/core/src/com/fallenflame/game/GameEngine.java
@@ -784,10 +784,10 @@ public class GameEngine implements Screen, InputProcessor {
         if(!isScreenActive()){
             return true;
         }
-        if(amount == 1){
+        if(amount == 1 && ALLOW_DEBUG){
             level.lightFromPlayer(-1.0f);
         }
-        if(amount == -1){
+        if(amount == -1 && ALLOW_DEBUG){
             level.lightFromPlayer(1.0f);
         }
 

--- a/core/src/com/fallenflame/game/util/InputBindings.java
+++ b/core/src/com/fallenflame/game/util/InputBindings.java
@@ -17,8 +17,6 @@ public class InputBindings {
         RESET_LEVEL,
         SNEAKING,
         SPRINTING,
-        INCREASE_LIGHT,
-        DECREASE_LIGHT,
     }
     private static final Map<Control, Integer> bindings;
     static {
@@ -109,8 +107,6 @@ public class InputBindings {
         bindings.put(Control.RESET_LEVEL, Input.Keys.R);
         bindings.put(Control.SNEAKING, Input.Keys.CONTROL_LEFT);
         bindings.put(Control.SPRINTING, Input.Keys.SHIFT_LEFT);
-        bindings.put(Control.INCREASE_LIGHT, Input.Keys.PERIOD);
-        bindings.put(Control.DECREASE_LIGHT, Input.Keys.COMMA);
         if (resetPrefs) {
             prefs.clear();
             prefs.flush();
@@ -214,8 +210,6 @@ public class InputBindings {
             case RESET_LEVEL: return "reset";
             case SNEAKING: return "sneak";
             case SPRINTING: return "sprint";
-            case INCREASE_LIGHT: return "incLightRad";
-            case DECREASE_LIGHT: return "decLightRad";
         }
         return null;
     }
@@ -228,16 +222,6 @@ public class InputBindings {
             case RESET_LEVEL: return new String[]{"reset"};
             case SNEAKING: return new String[]{"sneak"};
             case SPRINTING: return new String[]{"sprint"};
-            case INCREASE_LIGHT:
-                return new String[]{
-                        "incLightRad", "incLightrad", "inclightrad",
-                        "increaseLightRad", "increaseLightrad", "increaselightrad"
-                };
-            case DECREASE_LIGHT:
-                return new String[]{
-                        "decLightRad", "decLightrad", "declightrad",
-                        "decreaseLightRad", "decreaseLightrad", "decreaselightrad"
-                };
         }
         return null;
     }
@@ -250,8 +234,6 @@ public class InputBindings {
             case "reset": return Control.RESET_LEVEL;
             case "sneak": return Control.SNEAKING;
             case "sprint": return Control.SPRINTING;
-            case "inclightrad": case "increaselightrad": return Control.INCREASE_LIGHT;
-            case "declightrad": case "decreaselightrad": return Control.DECREASE_LIGHT;
         }
         return null;
     }
@@ -264,8 +246,6 @@ public class InputBindings {
             case RESET_LEVEL: return "Reset level";
             case SNEAKING: return "Sneaking";
             case SPRINTING: return "Sprinting";
-            case INCREASE_LIGHT: return "Increase light radius (secondary)";
-            case DECREASE_LIGHT: return "Decrease light radius (secondary)";
         }
         return null;
     }


### PR DESCRIPTION
- Removed the light scroll wheel as an option usable by the player
- Updated edit control screen to reflect that
- Kept light scrolling as a debug option --> ie when `ALLOW_DEBUG = true`, scroll wheel and comma/period still work