### PR TITLE
Make sprint deplete resource bar faster

### DIFF
--- a/core/assets/jsons/global.json
+++ b/core/assets/jsons/global.json
@@ -15,6 +15,8 @@
     "sneaklightrad":    1,
     "minlightradius":   2,
     "defaultStartSneakVal":   300,
+    "sprintDecRate": 1.4,
+    "sneakDecRate": 0.7,
     "texture":     	{
       "left": "player-left",
       "right": "player-right",

--- a/core/src/com/fallenflame/game/LevelController.java
+++ b/core/src/com/fallenflame/game/LevelController.java
@@ -635,7 +635,10 @@ public class LevelController implements ContactListener {
         // Decrement power value if player is sneaking or sprinting
         if((player.isSneaking() || player.isSprinting()) && player.isAlive()){
             if(player.getPowerVal() > 0){
-                player.decPowerVal();
+                if(player.isSprinting())
+                    player.decPowerValSprint();
+                else
+                    player.decPowerValSneak();
             }
             // Add ghost enemy if player has used all their power
             else if(player.getPowerVal() == 0 && ghostAdded == false) {

--- a/core/src/com/fallenflame/game/PlayerModel.java
+++ b/core/src/com/fallenflame/game/PlayerModel.java
@@ -314,8 +314,15 @@ public class PlayerModel extends CharacterModel {
     /** Get maximum amount of sneak and spring updates left for player on this level*/
     public int getMaxPowerVal() { return maxPowerVal; }
 
-    /** Decrement sneak and spring value by 1 (for 1 update of sneaking) */
-    public void decPowerVal() { powerVal--; }
+    /** Decrement resource value by 2 for sprinting (for 1 update of sprinting) */
+    public void decPowerValSprint() {
+        powerVal -= 2;
+    }
+
+    /** Decrement resource value by 1 for sneaking */
+    public void decPowerValSneak() {
+        powerVal--;
+    }
 
     /**
      * Gets player color tint

--- a/core/src/com/fallenflame/game/PlayerModel.java
+++ b/core/src/com/fallenflame/game/PlayerModel.java
@@ -40,8 +40,8 @@ public class PlayerModel extends CharacterModel {
     /** Max sneak and spring player can have at a given level */
     protected float maxPowerVal;
     /** Static resource decrease rates */
-    private static final float SPRINT_DEC_RATE = 1.4f;
-    private static final float SNEAK_DEC_RATE = 0.7f;
+    private float sprintDecRate;
+    private float sneakDecRate;
 
     /**Tint of player light */
     protected Color tint;
@@ -94,6 +94,8 @@ public class PlayerModel extends CharacterModel {
         lightRadius = minLightRadius;
         float[] tintValues = globalJson.get("tint").asFloatArray();//RGBA
         tint = new Color(tintValues[0], tintValues[1], tintValues[2], tintValues[3]);
+        sneakDecRate = globalJson.get("sneakDecRate").asFloat();
+        sprintDecRate = globalJson.get("sprintDecRate").asFloat();
 
         // Level json data
         flareCount = levelJson.has("startFlareCount") ?
@@ -319,12 +321,12 @@ public class PlayerModel extends CharacterModel {
 
     /** Decrement resource value by 2 for sprinting (for 1 update of sprinting) */
     public void decPowerValSprint() {
-        powerVal -= SPRINT_DEC_RATE;
+        powerVal -= sprintDecRate;
     }
 
     /** Decrement resource value by 1 for sneaking */
     public void decPowerValSneak() {
-        powerVal -= SNEAK_DEC_RATE;
+        powerVal -= sneakDecRate;
     }
 
     /**

--- a/core/src/com/fallenflame/game/PlayerModel.java
+++ b/core/src/com/fallenflame/game/PlayerModel.java
@@ -36,9 +36,12 @@ public class PlayerModel extends CharacterModel {
     protected float lightRadiusSneak;
     /** Player sneak and spring left (once hits 0, a ghost is deployed on the map)
      *  powerVal must be greater than or equal to 0 */
-    protected int powerVal;
+    protected float powerVal;
     /** Max sneak and spring player can have at a given level */
-    protected int maxPowerVal;
+    protected float maxPowerVal;
+    /** Static resource decrease rates */
+    private static final float SPRINT_DEC_RATE = 1.4f;
+    private static final float SNEAK_DEC_RATE = 0.7f;
 
     /**Tint of player light */
     protected Color tint;
@@ -100,7 +103,7 @@ public class PlayerModel extends CharacterModel {
         maxFlareCount = levelJson.has("maxFlareCount") ?
                 levelJson.get("maxFlareCount").asInt() : flareCount;
         powerVal = levelJson.has("startSneakVal") ?
-                levelJson.get("startSneakVal").asInt() : globalJson.get("defaultStartSneakVal").asInt();
+                levelJson.get("startSneakVal").asFloat() : globalJson.get("defaultStartSneakVal").asInt();
         maxPowerVal = powerVal;
 
         String walkSoundKey = globalJson.get("walksound").asString();
@@ -309,19 +312,19 @@ public class PlayerModel extends CharacterModel {
     }
 
     /** Get amount of sneak and spring updates left for player */
-    public int getPowerVal() { return powerVal; }
+    public float getPowerVal() { return powerVal; }
 
     /** Get maximum amount of sneak and spring updates left for player on this level*/
-    public int getMaxPowerVal() { return maxPowerVal; }
+    public float getMaxPowerVal() { return maxPowerVal; }
 
     /** Decrement resource value by 2 for sprinting (for 1 update of sprinting) */
     public void decPowerValSprint() {
-        powerVal -= 2;
+        powerVal -= SPRINT_DEC_RATE;
     }
 
     /** Decrement resource value by 1 for sneaking */
     public void decPowerValSneak() {
-        powerVal--;
+        powerVal -= SNEAK_DEC_RATE;
     }
 
     /**


### PR DESCRIPTION
Sprint now depletes resource bar 2x as fast as sneak.

Note: In general, levels going forward should (and will) have a high resource value.