### PR TITLE
Wall flare

### DIFF
--- a/core/assets/jsons/global.json
+++ b/core/assets/jsons/global.json
@@ -180,6 +180,7 @@
     "radius":      	  0.1,
     "lightradius":     3.5,
     "flareduration":  2500,
+    "fadeRate":       0.0005,
     "bodytype":    	  "dynamic",
     "density":        1.0,
     "friction":       0.0,

--- a/core/src/com/fallenflame/game/FlareModel.java
+++ b/core/src/com/fallenflame/game/FlareModel.java
@@ -33,6 +33,9 @@ public class FlareModel extends WheelObstacle implements ILight {
     /** Time when flare stuck to wall **/
     private long stuckTime;
 
+    /** Rate at which flare fades from wall **/
+    private float fadeRate;
+
     /** Light Radius */
     private float lightRadius;
 
@@ -199,6 +202,7 @@ public class FlareModel extends WheelObstacle implements ILight {
         setRadius(radius);
         lightRadius = json.get("lightradius").asFloat();
         flareDuration = json.get("flareduration").asInt();
+        fadeRate = json.get("fadeRate").asFloat();
         isStuck = false;
 
         // TODO #2: Technically, we should do error checking here.
@@ -301,7 +305,7 @@ public class FlareModel extends WheelObstacle implements ILight {
             if (timeToBurnout() == -1){
                 canvas.draw(texture, new Color(1, 1, 1, 1), origin.x, origin.y, getX() * drawScale.x, getY() * drawScale.y, getAngle(), 1.0f, 1.0f);
             } else {
-                canvas.draw(texture, new Color(1, 1, 1, .0005f * timeToBurnout()), origin.x, origin.y, getX() * drawScale.x, getY() * drawScale.y, getAngle(), 1.0f, 1.0f);
+                canvas.draw(texture, new Color(1, 1, 1, fadeRate * timeToBurnout()), origin.x, origin.y, getX() * drawScale.x, getY() * drawScale.y, getAngle(), 1.0f, 1.0f);
             }
         }
     }

--- a/core/src/com/fallenflame/game/FlareModel.java
+++ b/core/src/com/fallenflame/game/FlareModel.java
@@ -283,12 +283,12 @@ public class FlareModel extends WheelObstacle implements ILight {
 
     /**
      * How long until flare is deactived
-     * @return 1 if flare is not yet stuck to wall, otherwise returns stuck time left until burnout
+     * @return -1 if flare is not yet stuck to wall, otherwise returns stuck time left until burnout
      */
     public int timeToBurnout() {
         if(isStuck)
             return Math.max(flareDuration - (int) (System.currentTimeMillis() - stuckTime), 0);
-        return 1;
+        return -1;
     }
 
     /**
@@ -296,9 +296,13 @@ public class FlareModel extends WheelObstacle implements ILight {
      *
      * @param canvas Drawing context
      */
-    public void draw(ObstacleCanvas canvas) {
+    public void draw(GameCanvas canvas) {
         if (texture != null) {
-            canvas.draw(texture,Color.WHITE,origin.x,origin.y,getX()*drawScale.x,getY()*drawScale.y,getAngle(),1.0f,1.0f);
+            if (timeToBurnout() == -1){
+                canvas.draw(texture, new Color(1, 1, 1, 1), origin.x, origin.y, getX() * drawScale.x, getY() * drawScale.y, getAngle(), 1.0f, 1.0f);
+            } else {
+                canvas.draw(texture, new Color(1, 1, 1, .0005f * timeToBurnout()), origin.x, origin.y, getX() * drawScale.x, getY() * drawScale.y, getAngle(), 1.0f, 1.0f);
+            }
         }
     }
 }

--- a/core/src/com/fallenflame/game/LevelController.java
+++ b/core/src/com/fallenflame/game/LevelController.java
@@ -703,7 +703,7 @@ public class LevelController implements ContactListener {
         Iterator<FlareModel> i = flares.iterator();
         while(i.hasNext()){
             FlareModel flare = i.next();
-            if(!(Float.compare(flare.timeToBurnout(), 0.0f) > 0)){
+            if(flare.timeToBurnout() == 0){
                 flare.deactivatePhysics(world);
                 flare.dispose();
                 i.remove();

--- a/core/src/com/fallenflame/game/enemies/AITypeAController.java
+++ b/core/src/com/fallenflame/game/enemies/AITypeAController.java
@@ -162,7 +162,7 @@ public class AITypeAController extends AIController {
                 }
                 
                 // if flare died, or we reached investigation position and it wasn't a flare stop
-                if((enemy.isInvestigatingFlare() && (enemy.getInvestigateFlare().timeToBurnout() <= 0)) ||
+                if((enemy.isInvestigatingFlare() && (enemy.getInvestigateFlare().timeToBurnout() == 0)) ||
                         (investigateReached() && !enemy.isInvestigatingFlare())){
                     enemy.setInvestigatePosition(null);
                     enemy.clearInvestigateFlare();


### PR DESCRIPTION
Works but had to change things slightly in other parts. For some reason timeToBurnout() was using 1 to indicate is wasn't on a wall yet, and anything calling it was just checking if it was <= 0 to make sure it was burnt out. This was causing a pop at the 1ms mark on fading, so I changed it to return -1 for not being on a wall yet, and just had logic elsewhere check if timeToBurnout == 0 to see if it's burnt out since the time for a flare on wall doesn't seem to be able to go below 0 anyways (compares the time with 0 and chooses the max before returning).